### PR TITLE
Investigate and resolve reported issue

### DIFF
--- a/.github/workflows/update-blog-posts.yml
+++ b/.github/workflows/update-blog-posts.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
-          persist-credentials: false
+          persist-credentials: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c


### PR DESCRIPTION
The blog roll update workflow was failing with authentication error when trying to push changes. Fixed by:
- Setting persist-credentials to true
- Adding GITHUB_TOKEN to the checkout action

This matches the working configuration in update-contributions.yml